### PR TITLE
fix: :arrow_up: add compatibility for numpy>2.0

### DIFF
--- a/anf_generator/MixingMatrix.py
+++ b/anf_generator/MixingMatrix.py
@@ -18,7 +18,7 @@ class MixingMatrix:
         # Initialization
         M = self.get_num_channels()  # Number of channels
         K = self.get_nfft()  # Number of frequency bins
-        C = np.zeros((M, M, K), dtype=np.complex_)  # STFT mixing matrix
+        C = np.zeros((M, M, K), dtype=np.complex128)  # STFT mixing matrix
 
         # Direct Current component definition for the mixing matrix (fully coherent)
         C[:, :, 0] = np.ones((M, M)) / np.sqrt(M)

--- a/anf_generator/MixingMatrix.py
+++ b/anf_generator/MixingMatrix.py
@@ -122,10 +122,10 @@ class MixingMatrix:
         M = self.get_num_channels()  # Number of channels
 
         # Pre-allocate memory
-        c1_std = np.zeros((M, M, K1), dtype=np.complex_)
-        c1 = np.zeros((M, M, K1), dtype=np.complex_)
-        C2_std = np.zeros((M, M, K2), dtype=np.complex_)
-        C2 = np.zeros((M, M, K2), dtype=np.complex_)
+        c1_std = np.zeros((M, M, K1), dtype=np.complex128)
+        c1 = np.zeros((M, M, K1), dtype=np.complex128)
+        C2_std = np.zeros((M, M, K2), dtype=np.complex128)
+        C2 = np.zeros((M, M, K2), dtype=np.complex128)
 
         for p in range(M):
             for q in range(M):
@@ -147,8 +147,8 @@ class MixingMatrix:
         DC2 = CoherenceMatrix.CoherenceMatrix(params2)
 
         # Compute generated coherence with DFT-length K2 as C'*C and nMSE
-        G_std = np.zeros((M, M, K2 // 2 + 1), dtype=np.complex_)
-        G = np.zeros((M, M, K2 // 2 + 1), dtype=np.complex_)
+        G_std = np.zeros((M, M, K2 // 2 + 1), dtype=np.complex128)
+        G = np.zeros((M, M, K2 // 2 + 1), dtype=np.complex128)
         nMSEk_std = np.zeros(K2 // 2 + 1)
         nMSEk = np.zeros(K2 // 2 + 1)
         for k in range(K2 // 2 + 1):

--- a/anf_generator/__init__.py
+++ b/anf_generator/__init__.py
@@ -97,7 +97,7 @@ def estimate_coherence(x, nfft):
     M, K, L = X.shape  # Number of channels, frequencies, and frames
 
     # Compute PSD matrix
-    psd_matrix = np.zeros((M, M, K), dtype=np.complex_)
+    psd_matrix = np.zeros((M, M, K), dtype=np.complex128)
     for l in range(L):
         # Compute instantaneous spectrum for the l-th frame
         Xf = X[:, :, l].T
@@ -109,7 +109,7 @@ def estimate_coherence(x, nfft):
         psd_matrix += XX
 
     # Compute complex coherence matrix
-    CC = np.zeros((M, M, K), dtype=np.complex_)
+    CC = np.zeros((M, M, K), dtype=np.complex128)
     for r in range(M):
         for c in range(M):
             CC[r, c, :] = psd_matrix[r, c, :] / \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 pytest
-numpy>=1.6,<2.0
+numpy>=1.6
 scipy>=0.13.0
 matplotlib>=3.6


### PR DESCRIPTION
In numpy>2.0 np.complex_ is deprcated please see [namespace change](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#main-namespace)

